### PR TITLE
refactor(manager.py): refactor the `FILE_TYPE_MAP` map in manager module, for unified management of the left and right sides of the box ( when simple_format=False )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ logs/
 
 # test
 tests/archive.*
+tests/sample.*

--- a/cli/crm.py
+++ b/cli/crm.py
@@ -150,7 +150,7 @@ def main():
 
     # initialize counters and state
     exit_code = 0
-    stats = { "processed": 0, "skipped": 0, "updated": 0, "added": 0, "deleted": 0, "errors": 0, "debug": 0 }
+    stats = { "processed": 0, "matched": 0, "skipped": 0, "updated": 0, "added": 0, "deleted": 0, "errors": 0, "debug": 0 }
     forced_type = args.filetype.lower() if args.filetype else None
 
     for path in files_to_process:
@@ -167,7 +167,7 @@ def main():
             success, msg = False, 'unknown_operation'
             if args.check:
                 success, msg = manager.check_copyright_status( path, forced_type )
-                if msg == 'match': print( f"{COLOR_GREEN}OK" ); stats['skipped'] += 1
+                if msg == 'match': print( f"{COLOR_GREEN}OK" ); stats['matched'] += 1
                 elif msg == 'mismatch': print( f"{COLOR_YELLOW}NEEDS UPDATE{COLOR_RESET}" ); exit_code = 1
                 elif msg == 'not_found': print( f"{COLOR_YELLOW}NOT FOUND{COLOR_RESET}" ); exit_code = 1
                 else: raise ValueError( msg )
@@ -200,8 +200,6 @@ def main():
             if 'unsupported_format' in str(e):
                 print( f"{COLOR_YELLOW}UNSUPPORTED{COLOR_RESET}" )
                 print( f"{COLOR_BLUE}HINT: {COLOR_DEBUG_I}supported filetypes include: {COLOR_BLUE_I}{supported_types_str}{COLOR_RESET}" )
-            elif 'generate_failed' in str(e):
-                print( f"{COLOR_BOLD}ERROR: {COLOR_DEBUG_I}Failed to generate copyright for target format{COLOR_RESET}" )
             else:
                 print( f"{COLOR_BOLD}ERROR: {COLOR_DEBUG_I}{e}{COLOR_RESET}" )
             stats['errors'] += 1
@@ -217,7 +215,7 @@ def main():
         if args.debug:
             print( f"{COLOR_DEBUG_I}debug previews shown: {COLOR_CYAN}{stats['debug']}{COLOR_RESET}" )
         elif args.check:
-            print( f"{COLOR_DEBUG_I}MATCHED/OK: {COLOR_GREEN_I}{stats['skipped']}{COLOR_RESET}" )
+            print( f"{COLOR_DEBUG_I}MATCHED/OK: {COLOR_GREEN_I}{stats['matched']}{COLOR_RESET}" )
             print( f"{COLOR_DEBUG_I}needs action/not found: (see logs above){COLOR_RESET}"  )
         else:
             print( f"{COLOR_GRAY}ADDED   : {COLOR_GREEN_I}{stats['added']}{COLOR_RESET}" )

--- a/cli/libs/manager.py
+++ b/cli/libs/manager.py
@@ -23,37 +23,67 @@ from .helper import (
 # ====================== CONFIGURATION ======================
 LINE_LENGTH = 80
 
+# simple_format = True → no box; = False → box with box_left + box_char + box_right
+# comment       : core line marker for detection & content stripping (e.g. '#', '*')
+# content_left  : left delimiter of each content line
+# content_right : right delimiter of each content line
+# box_left      : left side of border line   ( simple_format=False only )
+# box_right     : right side of border line  ( simple_format=False only )
+# box_char      : repeated character forming the border run
 FILE_TYPE_MAP = {
+    # ============================================================================ #     → <box_left><box_char*n><box_right>
+    # Copyright © 2026 NAME                                                        #     → <content_left><..CONTENT..><content_right>
+    # Licensed under the NAME License, Version x.y                                 #     → <content_left><..CONTENT..><content_right>
+    # ============================================================================ #     → <box_left><box_char*n><box_right>
     'hash_comment': {
         'filetypes' : { 'python', 'shell', 'bash', 'sh', 'dockerfile' },
         'suffixes'  : { '.sh', '.py', '.dockerfile' },
         'config'    : {
             'start_line'     : '',
             'end_line'       : '',
-            'comment_string' : '#',
+            'comment'        : '#',     # core line marker: used for detection & content stripping
+            'content_left'   : '# ',
+            'content_right'  : ' #',
+            'box_left'       : '# ',
+            'box_right'      : ' #',
             'box_char'       : '=',
             'simple_format'  : False
         }
     },
+    # /**                                                                                → <start_line>
+    #  *******************************************************************************   → <box_left><box_char*n><box_right>
+    #  * Copyright © 2026 NAME                                                       *   → <content_left><..CONTENT..><content_right>
+    #  * Licensed under the NAME License, Version x.y                                *   → <content_left><..CONTENT..><content_right>
+    #  *******************************************************************************   → <box_left><box_char*n><box_right>
+    # **/                                                                                → <end_line>
     'groovy_style_comment': {
         'filetypes' : { 'jenkinsfile', 'groovy', 'gradle', 'java' },
         'suffixes'  : { '.groovy', '.java', '.gradle' },
         'config'    : {
             'start_line'     : '/**',
             'end_line'       : '**/',
-            'comment_string' : '* ',
+            'comment'        : '*',     # core line marker: used for detection & content stripping
+            'content_left'   : ' * ',
+            'content_right'  : ' *',
+            'box_left'       : ' ',
+            'box_right'      : '*',
             'box_char'       : '*',
             'simple_format'  : False
         }
     },
+    # /**                                                                                → <start_line>
+    #  * Copyright © 2026 NAME                                                           → <content_left><..CONTENT..><content_right>
+    #  * Licensed under the NAME License, Version x.y                                    → <content_left><..CONTENT..><content_right>
+    #  */                                                                                → <end_line>
     'c_style_comment': {
         'filetypes' : { 'c', 'cpp', 'c++', 'cxx', 'h', 'hpp', 'hxx' },
         'suffixes'  : { '.c', '.cpp', '.cxx', '.h', '.hpp', '.hxx' },
         'config'    : {
             'start_line'     : '/**',
             'end_line'       : ' */',
-            'comment_string' : ' * ',
-            'box_char'       : '*',
+            'comment'        : '*',     # core line marker: used for detection & content stripping
+            'content_left'   : ' * ',
+            'content_right'  : '',
             'simple_format'  : True
         }
     }
@@ -142,12 +172,8 @@ def detect_file_format( path: Path, filetype: Optional[str] = None ) -> Optional
             if 'bash' in first_line or 'sh' in first_line: return 'hash_comment'
             if 'groovy' in first_line: return 'groovy_style_comment'
 
-    # 5. re-check forced filetype as a potential suffix alias
+    # 5. forced filetype given but matched nothing above — warn and fall through to None
     if filetype:
-        normalized_ft = filetype.lower()
-        for fmt, data in FILE_TYPE_MAP.items():
-            if normalized_ft in data.get( 'filetypes', set() ):
-                return fmt
         print( f"{COLOR_YELLOW}WARNING: {COLOR_DEBUG}Forced filetype {COLOR_YELLOW_I}'{filetype}' {COLOR_DEBUG}is not in the known configurations.{COLOR_RESET}", file=sys.stderr )
 
 
@@ -182,11 +208,6 @@ class CopyrightManager:
         """Initializes the manager with the path to the copyright template file."""
         self.copyright_text = self._load_copyright( copyright_path )
         self.supported_types = get_supported_filetypes()
-        self.filetype_map: Dict[str, str] = {}
-        self.suffix_map: Dict[str, str] = {}
-        for fmt, data in FILE_TYPE_MAP.items():
-            for ft in data.get( "filetypes", set() ): self.filetype_map[ft] = fmt
-            for sfx in data.get( "suffixes", set() ): self.suffix_map[sfx] = fmt
 
     @staticmethod
     def _load_copyright( path: Path ) -> str:
@@ -199,6 +220,26 @@ class CopyrightManager:
         except Exception as e:
             print( f"{COLOR_RED}ERROR: {COLOR_DEBUG_I}Failed to read copyright file {COLOR_MAGENTA_I}{path}{COLOR_RESET} - {e}", file=sys.stderr )
             sys.exit(3)
+
+    @staticmethod
+    def _restore_trailing_newline( original: str, new_content: str ) -> str:
+        """Re-add trailing newline if original had one, or if original was empty (new file)."""
+        if new_content and not new_content.endswith('\n'):
+            if original.endswith('\n') or not original:
+                return new_content + '\n'
+        return new_content
+
+    @staticmethod
+    def _debug_preview( action: str, color: str, prep: str, path: Path, lines: List[str], verbose: bool ) -> None:
+        # pylint: disable=too-many-arguments too-many-positional-arguments
+        """Print a standardised debug preview block."""
+        header = (
+            f"\n{COLOR_DEBUG}--- DEBUG PREVIEW: {color}{action}{COLOR_RESET} "
+            f"{COLOR_DEBUG}{prep}{COLOR_RESET} {COLOR_MAGENTA}{path} "
+            f"{COLOR_DEBUG}---{COLOR_RESET}\n" if verbose else "\n"
+        )
+        footer = f"\n{COLOR_DEBUG}--- END PREVIEW ---{COLOR_RESET}" if verbose else ""
+        print( f"{header}{COLOR_GRAY_I}{chr(10).join(lines)}{COLOR_RESET}{footer}", end="\n" )
 
     def _get_format_from_filetype( self, filetype: str ) -> Optional[str]:
         """Utility to get format key from a filetype string."""
@@ -226,42 +267,34 @@ class CopyrightManager:
 
         target = f"type {COLOR_MAGENTA_I}'{forced_filetype}'" if forced_filetype else f"file {COLOR_MAGENTA_I}'{path}'"
         print( f"{COLOR_CYAN}INFO: {COLOR_DEBUG_I}could not determine a supported format for {target}{COLOR_RESET}", file=sys.stderr )
-        supported_ft_list = get_supported_filetypes()
-        if supported_ft_list:
-            hint = f"{COLOR_CYAN}HINT: {COLOR_DEBUG}Supported filetypes are: {COLOR_MAGENTA_I}{', '.join(supported_ft_list)}{COLOR_RESET}"
+        if self.supported_types:
+            hint = f"{COLOR_CYAN}HINT: {COLOR_DEBUG}Supported filetypes are: {COLOR_MAGENTA_I}{', '.join(self.supported_types)}{COLOR_RESET}"
             print( hint, file=sys.stderr )
         return None
 
     def _format_copyright_content_lines( self, fmt: str, bordered: bool ) -> List[str]:
         """Generates just the content lines of a copyright block."""
         config = FILE_TYPE_MAP[fmt]["config"]
-        comment_string = config.get( 'comment_string', '#' )
+        content_left  = config.get( 'content_left',  '# ' )
+        content_right = config.get( 'content_right', ' #' )
         processed_text_lines = _preprocess_copyright_text( self.copyright_text )
         content_lines = []
 
-        if not bordered:      # simple format content
-            line_prefix = comment_string.rstrip() + ' '
-            wrap_width = max( 10, LINE_LENGTH - len(line_prefix) )
+        if not bordered:      # simple format: no box, just a left prefix per line
+            wrap_width = max( 10, LINE_LENGTH - len(content_left) )
             for line in processed_text_lines:
                 if not line:
-                    content_lines.append( comment_string.rstrip() )
+                    content_lines.append( content_left.rstrip() )
                 else:
                     wrapped = textwrap.wrap( line, width=wrap_width, replace_whitespace=False, drop_whitespace=False )
                     for part in wrapped:
-                        content_lines.append( f"{line_prefix}{part}" )
-        else:                 # bordered format content
-            if config.get( "start_line" ):
-                left_content  = ' ' + comment_string.strip() + ' '
-                right_content = ' ' + comment_string.strip()
-            else:
-                left_content  = comment_string + ' '
-                right_content = ' ' + comment_string
-
-            text_width = max( 0, LINE_LENGTH - len(left_content) - len(right_content) )
+                        content_lines.append( f"{content_left}{part}" )
+        else:                 # bordered format: pad text between left and right delimiters
+            text_width = max( 0, LINE_LENGTH - len(content_left) - len(content_right) )
             for line in processed_text_lines:
                 wrapped = textwrap.wrap( line, width=text_width, replace_whitespace=False, drop_whitespace=False ) if line else [""]
                 for part in wrapped:
-                    content_lines.append( f"{left_content}{part.ljust(text_width)}{right_content}" )
+                    content_lines.append( f"{content_left}{part.ljust(text_width)}{content_right}" )
         return content_lines
 
     def _format_copyright_as_list( self, fmt: str ) -> List[str]:
@@ -279,23 +312,21 @@ class CopyrightManager:
         if simple_format:
             full_block.extend( self._format_copyright_content_lines(fmt, bordered=False) )
         else:                 # bordered format
-            box_char = config.get( 'box_char', '=' )
-            comment_string = config.get( 'comment_string', '#' )
+            missing = [ k for k in ('box_char', 'box_left', 'box_right') if k not in config ]
+            if missing:
+                raise ValueError( f"Format '{fmt}' has simple_format=False but is missing required box keys: {missing}" )
 
-            if start_line:
-                left_border_prefix = ' '
-                right_border_suffix = comment_string.strip()
-            else:
-                left_border_prefix = comment_string.strip() + ' '
-                right_border_suffix = ' ' + comment_string.strip()
+            box_char  = config['box_char']
+            box_left  = config['box_left']
+            box_right = config['box_right']
 
-            border_width = max( 0, LINE_LENGTH - len(left_border_prefix) - len(right_border_suffix) - len(box_char) * 2 )
-            border_line  = f"{left_border_prefix}{box_char}{box_char * border_width}{box_char}{right_border_suffix}"
+            box_width = max( 0, LINE_LENGTH - len(box_left) - len(box_right) - len(box_char) * 2 )
+            box_line  = f"{box_left}{box_char}{box_char * box_width}{box_char}{box_right}"
 
             lines = []
-            lines.append( border_line )
+            lines.append( box_line )
             lines.extend( self._format_copyright_content_lines(fmt, bordered=True) )
-            lines.append( border_line )
+            lines.append( box_line )
             full_block.extend( lines )
 
         if end_line: full_block.append( end_line )
@@ -317,8 +348,9 @@ class CopyrightManager:
 
         return -1, -1
 
-    def _isolate_copyright_in_simple_block( self, lines: List[str], block_start: int, block_end: int ) -> Tuple[int, int]:
+    def _isolate_copyright_in_simple_block( self, lines: List[str], block_start: int, block_end: int, fmt: str ) -> Tuple[int, int]:
         """Finds the precise start and end of the copyright section within a simple block."""
+        comment = FILE_TYPE_MAP[fmt]['config']['comment']
         cr_start = -1
         for i in range( block_start, block_end ):
             if COPYRIGHT_KEYWORD_PAT.search( lines[i] ): cr_start = i; break
@@ -330,7 +362,7 @@ class CopyrightManager:
             line = lines[i]
             if AUTHOR_KEYWORD_PAT.search( line ): break
 
-            line_content = line.strip().lstrip( FILE_TYPE_MAP['c_style_comment']['config']['comment_string'].strip() ).strip()
+            line_content = line.strip().lstrip( comment ).strip()
             if not line_content: break
 
             cr_end = i
@@ -340,18 +372,17 @@ class CopyrightManager:
     def _find_bordered_section( self, lines: List[str], block_start: int, block_end: int, fmt: str ) -> Tuple[int, int]:
         """Find the start and end line indexes of the bordered copyright section."""
         config = FILE_TYPE_MAP[fmt]['config']
-        comment = config.get( 'comment_string', '#' )
-        box_char = config.get( 'box_char', '=' )
+        box_char     = config.get( 'box_char', '=' )
         start_marker = config.get( 'start_line', '' )
-
-        right_suffix = re.escape( comment.strip() )
+        c   = re.escape( config.get('comment', '#') )
         box = re.escape( box_char )
-        left_prefix = re.escape( comment.strip() )
 
         if start_marker:
-            border_re = re.compile( rf"^\s*{box}{{3,}}{right_suffix}\s*$" )
+            # groovy: border line is whitespace + box_char run + core marker (e.g. " ****...**")
+            border_re = re.compile( rf"^\s*{box}{{3,}}{c}\s*$" )
         else:
-            border_re = re.compile( rf"^\s*{left_prefix}\s*{box}{{3,}}(?:\s*{right_suffix})?\s*$" )
+            # hash: border line is "# ===...=== #"
+            border_re = re.compile( rf"^\s*{c}\s*{box}{{3,}}(?:\s*{c})?\s*$" )
 
         borders = [ i for i in range(block_start, block_end + 1) if border_re.match(lines[i]) ]
         if len(borders) >= 2: return borders[0], borders[-1]
@@ -361,8 +392,8 @@ class CopyrightManager:
         # pylint: disable=too-many-locals,too-many-branches
         """Finds the first continuous block of comments."""
         config = FILE_TYPE_MAP[fmt]['config']
-        start_marker = config.get( 'start_line', '' )
-        comment_string = config.get( 'comment_string', '#' )
+        start_marker   = config.get( 'start_line', '' )
+        comment_marker = config.get( 'comment', '#' )
 
         block_start, in_block = -1, False
 
@@ -380,10 +411,10 @@ class CopyrightManager:
                     return block_start, i
         else:                 # line comment
             # exclude shebang lines (#!) so they don't absorb the first comment block
-            if comment_string.strip() == '#':
+            if comment_marker == '#':
                 comment_pat = re.compile( r"^\s*#(?!!)" )
             else:
-                comment_pat = re.compile( r"^\s*" + re.escape(comment_string.strip()) )
+                comment_pat = re.compile( r"^\s*" + re.escape(comment_marker) )
             for i in range( search_start_idx, len(lines) ):
                 line = lines[i]
                 if comment_pat.match( line ):
@@ -406,7 +437,7 @@ class CopyrightManager:
 
         config = FILE_TYPE_MAP[fmt]['config']
         if config.get( 'simple_format', False ):
-            cr_start, cr_end = self._isolate_copyright_in_simple_block( lines, block_start, block_end + 1 )
+            cr_start, cr_end = self._isolate_copyright_in_simple_block( lines, block_start, block_end + 1, fmt )
             if cr_start != -1:
                 return '\n'.join( lines[cr_start : cr_end + 1] )
             return None
@@ -422,7 +453,7 @@ class CopyrightManager:
     def _is_blank_comment_line( line: str, config: Dict ) -> bool:
         """Checks if a line is a blank comment line."""
         stripped = line.strip()
-        comment_marker = config['comment_string'].strip()
+        comment_marker = config.get( 'comment', '' )
         if not comment_marker:
             return not stripped
         return stripped == comment_marker
@@ -449,8 +480,8 @@ class CopyrightManager:
             del_start, del_end = -1, -1
             if not is_simple_format:
                 del_start, del_end = self._find_bordered_section( lines, block_start, block_end, fmt )
-            elif is_simple_format:
-                del_start, del_end = self._isolate_copyright_in_simple_block( lines, block_start, block_end + 1 )
+            else:
+                del_start, del_end = self._isolate_copyright_in_simple_block( lines, block_start, block_end + 1, fmt )
 
             # ======================== find the copyright block ========================
             if del_start != -1:
@@ -478,21 +509,10 @@ class CopyrightManager:
                     del_end += 1
 
                 new_lines = lines[:del_start] + lines[del_end + 1:]
-                final_content = '\n'.join( new_lines )
-                if content.endswith('\n') and final_content and not final_content.endswith('\n'):
-                    final_content += '\n'
+                final_content = self._restore_trailing_newline( content, '\n'.join(new_lines) )
 
                 if debug:
-                    header = (
-                        f"\n{COLOR_DEBUG}--- DEBUG PREVIEW: {COLOR_RED_I}DELETE{COLOR_RESET} "
-                        f"{COLOR_DEBUG}from{COLOR_RESET} {COLOR_MAGENTA}{path} "
-                        f"{COLOR_DEBUG}---{COLOR_RESET}\n" if verbose else "\n"
-                    )
-                    footer = f"\n{COLOR_DEBUG}--- END PREVIEW ---{COLOR_RESET}" if verbose else ""
-
-                    deleted_snippet = lines[del_start : del_end + 1]
-                    dbg_output = "\n".join(deleted_snippet)
-                    print(f"{header}{COLOR_GRAY_I}{dbg_output}{COLOR_RESET}{footer}", end="\n")
+                    self._debug_preview( 'DELETE', COLOR_RED_I, 'from', path, lines[del_start : del_end + 1], verbose )
                     return True, 'debug_deleted'
 
                 path.write_text( final_content, encoding='utf-8' )
@@ -506,18 +526,10 @@ class CopyrightManager:
                 remove_end += 1
 
             new_lines = lines[ :block_start ] + lines[ remove_end + 1: ]
-            final_content = '\n'.join( new_lines )
-            if content.endswith('\n') and final_content and not final_content.endswith('\n'):
-                final_content += '\n'
+            final_content = self._restore_trailing_newline( content, '\n'.join(new_lines) )
 
             if debug:
-                header = (
-                    f"\n{COLOR_DEBUG}--- DEBUG PREVIEW: {COLOR_RED_I}DELETE{COLOR_RESET} "
-                    f"{COLOR_DEBUG}from{COLOR_RESET} {COLOR_MAGENTA}{path} "
-                    f"{COLOR_DEBUG}---{COLOR_RESET}\n" if verbose else "\n"
-                )
-                footer = f"\n{COLOR_DEBUG}--- END PREVIEW ---{COLOR_RESET}" if verbose else ""
-                print( f"{header}{COLOR_GRAY_I}{COLOR_RESET}{footer}", end="\n" )
+                self._debug_preview( 'DELETE', COLOR_RED_I, 'from', path, lines[block_start : remove_end + 1], verbose )
                 return True, 'debug_deleted'
 
             path.write_text( final_content, encoding='utf-8' )
@@ -575,20 +587,10 @@ class CopyrightManager:
             new_lines.append('')
 
         new_lines.extend( lines[insert_pos:] )
-        final_content = '\n'.join( new_lines )
-        if content.endswith('\n') or ( not content and final_content ):
-            if not final_content.endswith('\n'):
-                final_content += '\n'
+        final_content = self._restore_trailing_newline( content, '\n'.join(new_lines) )
 
         if debug:
-            header = (
-                f"\n{COLOR_DEBUG}--- DEBUG PREVIEW: {COLOR_GREEN_I}ADD{COLOR_RESET} "
-                f"{COLOR_DEBUG}to{COLOR_RESET} {COLOR_MAGENTA}{path} "
-                f"{COLOR_DEBUG}---{COLOR_RESET}\n" if verbose else '\n'
-            )
-            footer = f"\n{COLOR_DEBUG}--- END PREVIEW ---{COLOR_RESET}" if verbose else ""
-            debug_output = '\n'.join( formatted_lines )
-            print( f"{header}{COLOR_GRAY_I}{debug_output}{COLOR_RESET}{footer}", end="\n" )
+            self._debug_preview( 'ADD', COLOR_GREEN_I, 'to', path, formatted_lines, verbose )
             return True, 'debug_added'
 
         path.write_text( final_content, encoding='utf-8' )
@@ -630,34 +632,22 @@ class CopyrightManager:
 
             # Simple formats that contain other info: narrow to the actual subrange
             if is_simple_format and has_other_info:
-                cr_start, cr_end = self._isolate_copyright_in_simple_block( lines, block_start, block_end + 1 )
+                cr_start, cr_end = self._isolate_copyright_in_simple_block( lines, block_start, block_end + 1, fmt )
                 if cr_start != -1:
                     replace_start, replace_end = cr_start, cr_end
                     lines_to_insert = self._format_copyright_content_lines( fmt, bordered=False )
 
             if debug:
-                header = (
-                    f"\n{COLOR_DEBUG}--- DEBUG PREVIEW: {COLOR_CYAN_I}UPDATE{COLOR_RESET} "
-                    f"{COLOR_DEBUG}for{COLOR_RESET} {COLOR_MAGENTA}{path} "
-                    f"{COLOR_DEBUG}---{COLOR_RESET}\n" if verbose else "\n"
+                preview = (
+                    lines[block_start:replace_start] + lines_to_insert + lines[replace_end + 1:block_end + 1]
+                    if replace_start != block_start or replace_end != block_end
+                    else new_formatted_lines
                 )
-                footer = f"\n{COLOR_DEBUG}--- END PREVIEW ---{COLOR_RESET}" if verbose else ""
-                if replace_start != block_start or replace_end != block_end:
-                    debug_output_lines = (
-                        lines[block_start:replace_start] +
-                        lines_to_insert +
-                        lines[replace_end + 1:block_end + 1]
-                    )
-                else:
-                    debug_output_lines = new_formatted_lines
-                debug_output = '\n'.join( debug_output_lines )
-                print( f"{header}{COLOR_GRAY_I}{debug_output}{COLOR_RESET}{footer}", end='\n' )
+                self._debug_preview( 'UPDATE', COLOR_CYAN_I, 'for', path, preview, verbose )
                 return True, 'debug_updated'
 
             new_lines = lines[:replace_start] + lines_to_insert + lines[replace_end + 1:]
-            final_content = '\n'.join( new_lines )
-            if content.endswith('\n') and not final_content.endswith('\n'):
-                final_content += '\n'
+            final_content = self._restore_trailing_newline( content, '\n'.join(new_lines) )
 
             path.write_text( final_content, encoding='utf-8' )
             return True, 'updated'
@@ -668,6 +658,9 @@ class CopyrightManager:
     def add_copyright( self, path: Path, forced_type: Optional[str] = None, debug: bool = False, verbose: bool = False ) -> Tuple[bool, str]:
         """Adds copyright: Skips if match, updates if mismatch, inserts if not found."""
         try:
+            fmt = detect_file_format( path, forced_type )
+            if not fmt: raise ValueError( 'unsupported_format' )
+
             _, status = self.check_copyright_status( path, forced_type )
 
             if status == 'match':
@@ -675,9 +668,6 @@ class CopyrightManager:
             if status == 'mismatch':
                 return self.update_copyright( path, forced_type, debug=debug, verbose=verbose )
             if status == 'not_found':
-                fmt = detect_file_format( path, forced_type )
-                if not fmt: raise ValueError( 'unsupported_format' )
-
                 formatted_lines = self._format_copyright_as_list( fmt )
                 content = path.read_text( encoding='utf-8' )
                 return self._insert_copyright( path, content, formatted_lines, fmt, debug=debug, verbose=verbose )


### PR DESCRIPTION
refactor(manager.py): refactor the `FILE_TYPE_MAP` map in manager module, for unified management of the left and right sides of the box ( when simple_format=False )

- comment       : core line marker for detection & content stripping (e.g. '#', '*')
- content_left  : left delimiter of each content line
- content_right : right delimiter of each content line
- box_left      : left side of border line   ( simple_format=False only )
- box_right     : right side of border line  ( simple_format=False only )
- box_char      : repeated character forming the border run

Signed-off-by: marslo <marslo.jiao@gmail.com>