### PR TITLE
fix(check): fix false mismatch for bordered copyright formats and skip redundant updates

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,31 @@
+---
+name: pre-commit
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      # manual execute pre-commit，instead of `- uses: pre-commit/action@v3.0.1`
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pre-commit run --show-diff-on-failure --color=always \
+              --from-ref "${{ github.event.pull_request.base.sha }}" \
+              --to-ref "${{ github.event.pull_request.head.sha }}"
+          else
+            pre-commit run --show-diff-on-failure --color=always --all-files
+          fi

--- a/cli/crm.py
+++ b/cli/crm.py
@@ -30,7 +30,7 @@ DEFAULT_COPYRIGHT_FILE = "COPYRIGHT"
 
 _ANSI_ESC_RE = re.compile( r'\x1b\[[0-9;]*m' )
 
-def _format_progress_line( counter_c: str, path: Path, status_c: str, total_width: int = 80, min_dots: int = 3 ) -> str:
+def _format_progress_line( counter_c: str, path: Path, status_c: str, total_width: int = 79, min_dots: int = 3 ) -> str:
     """Format a fixed-width progress line (pre-commit style): counter path ... status."""
     counter_p = _ANSI_ESC_RE.sub( '', counter_c )
     status_p  = _ANSI_ESC_RE.sub( '', status_c )
@@ -201,8 +201,9 @@ def main():
                 success, msg = manager.update_copyright( path, forced_type, debug=args.debug, verbose=args.verbose )
                 if   msg.startswith('debug'): status_c = f"{COLOR_DEBUG_I}(preview){COLOR_RESET}";   stats['debug'] += 1
                 elif success:
-                    if   msg == 'updated' : status_c = f"{COLOR_CYAN}UPDATED{COLOR_RESET}";           stats['updated'] += 1
-                    elif msg == 'inserted': status_c = f"{COLOR_GREEN}ADDED{COLOR_RESET}";             stats['added'] += 1
+                    if   msg == 'skipped' : status_c = f"{COLOR_DEBUG}SKIPPED{COLOR_RESET}";           stats['skipped'] += 1
+                    elif msg == 'updated' : status_c = f"{COLOR_CYAN}UPDATED{COLOR_RESET}";            stats['updated'] += 1
+                    elif msg == 'inserted': status_c = f"{COLOR_GREEN}ADDED{COLOR_RESET}";              stats['added'] += 1
                     else: raise ValueError( msg )
                 else: raise ValueError( msg )
 

--- a/cli/libs/manager.py
+++ b/cli/libs/manager.py
@@ -416,6 +416,21 @@ class CopyrightManager:
             return not stripped
         return stripped == comment_marker
 
+    def _is_copyright_match( self, current: str, fmt: str, formatted_lines: Optional[List[str]] = None ) -> bool:
+        """Compare existing copyright text against expected output, ignoring wrapper lines and trailing whitespace."""
+        config = FILE_TYPE_MAP[fmt]['config']
+        if config.get( 'simple_format', False ):
+            norm_expected = "\n".join( line.strip() for line in self._format_copyright_content_lines(fmt, bordered=False) )
+        else:
+            exp = list( formatted_lines or self._format_copyright_as_list(fmt) )
+            start_line = config.get( 'start_line', '' )
+            end_line   = config.get( 'end_line',   '' )
+            if start_line and exp and exp[0] == start_line: exp.pop(0)
+            if end_line and exp and exp[-1] == end_line: exp.pop()
+            norm_expected = "\n".join( line.strip() for line in exp )
+        norm_current = "\n".join( line.strip() for line in current.strip().splitlines() )
+        return norm_current == norm_expected
+
     def delete_copyright( self, path: Path, forced_type: Optional[str] = None, debug: bool = False, verbose: bool = False ) -> Tuple[bool, str]:
         # pylint: disable=too-many-branches,too-many-locals,too-many-return-statements,too-many-statements
         """Delete the copyright header. Prefer removing only the bordered section when present."""
@@ -508,15 +523,7 @@ class CopyrightManager:
             current = self._get_current_copyright( content, fmt )
             if not current: return False, 'not_found'
 
-            config = FILE_TYPE_MAP[fmt]['config']
-            if config.get( 'simple_format', False ):
-                norm_expected = "\n".join( line.strip() for line in self._format_copyright_content_lines(fmt, bordered=False) )
-            else:
-                norm_expected = "\n".join( line.strip() for line in self._format_copyright_as_list(fmt) )
-
-            norm_current = "\n".join( line.strip() for line in current.strip().splitlines() )
-
-            if norm_current == norm_expected: return True, 'match'
+            if self._is_copyright_match( current, fmt ): return True, 'match'
             return False, 'mismatch'
         except FileNotFoundError: return False, 'error: file_not_found'
         except Exception as e: return False, f"error: {e}"
@@ -563,6 +570,11 @@ class CopyrightManager:
 
             new_formatted_lines = self._format_copyright_as_list( fmt )
             content = path.read_text( encoding='utf-8' )
+            current = self._get_current_copyright( content, fmt )
+
+            if current and self._is_copyright_match( current, fmt, new_formatted_lines ):
+                return True, 'skipped'
+
             lines = content.splitlines()
 
             block_start, block_end = self._detect_copyright_block( lines, fmt )
@@ -619,17 +631,17 @@ class CopyrightManager:
             fmt = detect_file_format( path, forced_type )
             if not fmt: raise ValueError( 'unsupported_format' )
 
-            _, status = self.check_copyright_status( path, forced_type )
+            content = path.read_text( encoding='utf-8' )
+            current = self._get_current_copyright( content, fmt )
 
-            if status == 'match':
-                return True, 'skipped'
-            if status == 'mismatch':
-                return self.update_copyright( path, forced_type, debug=debug, verbose=verbose )
-            if status == 'not_found':
+            if not current:
                 formatted_lines = self._format_copyright_as_list( fmt )
-                content = path.read_text( encoding='utf-8' )
                 return self._insert_copyright( path, content, formatted_lines, fmt, debug=debug, verbose=verbose )
-            raise ValueError( status )
+
+            if self._is_copyright_match( current, fmt ):
+                return True, 'skipped'
+
+            return self.update_copyright( path, forced_type, debug=debug, verbose=verbose )
         except FileNotFoundError: return False, 'file_not_found'
         except Exception as e: return False, f"error: {e}"
 


### PR DESCRIPTION
fix(check): fix false mismatch for bordered copyright formats and skip redundant updates

- strip start_line/end_line from expected block in `check_copyright_status` so bordered formats (groovy/java) match correctly after first insertion
- add match-check to update_copyright to skip when copyright already matches
- adjust progress line width from 80 to 79 to align with pre-commit output

Fixes #36

Signed-off-by: marslo <marslo.jiao@gmail.com>